### PR TITLE
feat: add fixtures to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ RUN curl -ILv https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
 WORKDIR /opt/controller
 
 COPY src /opt/controller/
+COPY fixtures /opt/
 
 ENTRYPOINT ["gunicorn", "-b", "0.0.0.0:5000", "controller:server"]


### PR DESCRIPTION
Add fixtures to docker images because they are needed by the controller to creates messages.